### PR TITLE
use the correct WETH address from bridge

### DIFF
--- a/fuji.tokenlist.json
+++ b/fuji.tokenlist.json
@@ -12,7 +12,7 @@
     "timestamp": "2021-01-05T00:00:00+00:00",
     "tokens": [
         {
-            "address": "0xB767287A7143759f294CfB7b1Adbca1140F3de71",
+            "address": "0x7fCDc2C1EF3e4A0bCC8155a558bB20a7218f2b05",
             "chainId": 43113,
             "name": "Wrapped Ether",
             "symbol": "WETH",


### PR DESCRIPTION
bridge in fuji uses a different address for eth. this way the balances will show up correctly